### PR TITLE
Fix build with FreeBSD and OpenBSD

### DIFF
--- a/src/graphics/screenshot.cpp
+++ b/src/graphics/screenshot.cpp
@@ -1,7 +1,7 @@
 #include "pngfuncs.h"
 #include "graphics.h"
 #include "../common/stat.h"
-#if defined(__MACH__)
+#if defined(__MACH__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <cstdlib>
 #else
 #include <malloc.h>


### PR DESCRIPTION
This patch fixes build with both FreeBSD and OpenBSD. Both of those systems don't have malloc.h. Instead, stdlib.h should be used.