### PR TITLE
Fix potential typo in end scene

### DIFF
--- a/src/endgame/misc.cpp
+++ b/src/endgame/misc.cpp
@@ -372,7 +372,7 @@ Object *ahchoo;
 		
 		case 50:	// turn back to mimiga...
 		{
-			o->state = 41;
+			o->state = 51;
 			o->timer = 0;
 			o->frame = 0;
 		}


### PR DESCRIPTION
Found this one while working on `switch` fall-throughs.
This one seems wrong from context. However, not played that far actually.