### PR TITLE
Added "stage_Filename"-style translation support for stage names.

### DIFF
--- a/src/TextBox/SaveSelect.cpp
+++ b/src/TextBox/SaveSelect.cpp
@@ -198,8 +198,8 @@ const int w = fCoords.w - 33;
 	
 	if (fHaveProfile[index])
 	{
-		const char *stage = map_get_stage_name(p->stage);
-		font_draw(x+8, y-1, _(stage));
+		const std::string& stage = map_get_stage_name(p->stage);
+		font_draw(x+8, y-1, stage);
 		
 		// draw health.
 		DrawHealth(x+w, y, p);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1103,18 +1103,23 @@ void map_ChangeTileWithSmoke(int x, int y, int newtile, int nclouds, bool boomfl
 
 
 
-const char *map_get_stage_name(int mapno)
+const std::string& map_get_stage_name(int mapno)
 {
-	if (mapno == STAGE_KINGS)
-		return "";//"Studio Pixel Presents";
-	
-	return stages[mapno].stagename;
+	std::string stagename = (std::string)"stage_" + stages[mapno].filename;
+	if (_(stagename) == stagename)
+	{
+		if (mapno == STAGE_KINGS)
+			stagename = "";//"Studio Pixel Presents";
+		return _(stages[mapno].stagename);
+	}
+	else
+		return _(stagename);
 }
 
 // show map name for "ticks" ticks
 void map_show_map_name()
 {
-	game.mapname_x = (SCREEN_WIDTH / 2) - (GetFontWidth(_(map_get_stage_name(game.curmap))) / 2);
+	game.mapname_x = (SCREEN_WIDTH / 2) - (GetFontWidth(map_get_stage_name(game.curmap)) / 2);
 	game.showmapnametime = 120;
 }
 
@@ -1122,7 +1127,7 @@ void map_draw_map_name(void)
 {
 	if (game.showmapnametime)
 	{
-		font_draw(game.mapname_x, 84, _(map_get_stage_name(game.curmap)), 0xFFFFFF, true);
+		font_draw(game.mapname_x, 84, map_get_stage_name(game.curmap), 0xFFFFFF, true);
 		game.showmapnametime--;
 	}
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1109,9 +1109,10 @@ const std::string& map_get_stage_name(int mapno)
 	stagename = (std::string)"stage_" + stages[mapno].filename;
 	if (_(stagename) == stagename)
 	{
+		stagename = stages[mapno].stagename;
 		if (mapno == STAGE_KINGS)
 			stagename = "";//"Studio Pixel Presents";
-		return _(stages[mapno].stagename);
+		return _(stagename);
 	}
 	else
 		return _(stagename);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1105,7 +1105,8 @@ void map_ChangeTileWithSmoke(int x, int y, int newtile, int nclouds, bool boomfl
 
 const std::string& map_get_stage_name(int mapno)
 {
-	std::string stagename = (std::string)"stage_" + stages[mapno].filename;
+	static std::string stagename;
+	stagename = (std::string)"stage_" + stages[mapno].filename;
 	if (_(stagename) == stagename)
 	{
 		if (mapno == STAGE_KINGS)

--- a/src/map.h
+++ b/src/map.h
@@ -147,7 +147,7 @@ void map_scroll_jump(int x, int y);
 void map_scroll_lock(bool lockstate);
 void map_focus(Object *o, int spd);
 void map_ChangeTileWithSmoke(int x, int y, int newtile, int nclouds, bool boomflash, Object *push_behind);
-const char *map_get_stage_name(int mapno);
+const std::string& map_get_stage_name(int mapno);
 void map_show_map_name();
 void map_draw_map_name(void);
 void AnimateMotionTiles(void);


### PR DESCRIPTION
This allows individual translation of maps which share a name, and translation of stage names regardless of whether the AGTP or any other version of the game (Japanese or CS+) is used as the base.

(Aside: I recognise that the Japanese TSC scripts are probably in Shift-JIS not UTF-8, so if it's used as a base then setting a localization will probably be mandatory. Not necessarily as big of a deal as it might seem!)

Example:
`data/lang/japanese/system.json` can now contain:
```
  "stage_0": "無",
  "stage_Pens1": "アーサーの家",
  "stage_Pens2": "アーサーの家",
  "stage_Eggs": "タマゴ回廊",
  "stage_EggX": "タマゴ No.00",
  "stage_Egg6": "タマゴ No.06",
  "stage_EggR": "タマゴ監視室",
  "stage_Weed": "クサムラ",
```
(etc.)
and it will translate the same regardless of what names are actually in `stage.dat`.


Moved map name translations into `map_get_stage_name` to accommodate this functionality. (It now returns a fully translated `std::string` reference.)

Does **not** break existing translations! Translating by AGTP stagename (from stages.dat) is a fallback.
I would like to call that depreciated, but making that transition is up to you.