### PR TITLE
WIP: Player collision fixes

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -617,13 +617,13 @@ int limit;
 		//		of a high inertia when he hit it
 		if (player->blockr)
 		{
-			limit = (player->dir == RIGHT) ? 0x180 : 0;
+			limit = (pinputs[RIGHTKEY]) ? 0x180 : 0;
 			if (player->xinertia > limit) player->xinertia = limit;
 		}
 		
 		if (player->blockl)
 		{
-			limit = (player->dir == LEFT) ? -0x180 : 0;
+			limit = (pinputs[LEFTKEY]) ? -0x180 : 0;
 			if (player->xinertia < limit) player->xinertia = limit;
 		}
 	}


### PR DESCRIPTION
I cherry-picked an old commit from @Clownacy to the latest master so it's mergable.
https://github.com/Clownacy/nxengine-evo/commit/eb0da2fd0f287194751ee8d89f9cc1d0b857dd07

I think the difference is mainly what happens when you use the Booster 2.0 to go horizontally but don't hold the directional key down. Also affects physics when you're getting thrown around by something in a direction you happen to be facing, I guess?