### PR TITLE
Fix Curly boss causes no damage (#95)

### DIFF
--- a/src/ai/sand/curly_boss.cpp
+++ b/src/ai/sand/curly_boss.cpp
@@ -165,7 +165,6 @@ static void curlyboss_fire(Object *o, int dir)
 {
   Object *shot = SpawnObjectAtActionPoint(o, OBJ_CURLYBOSS_SHOT);
 
-  shot->damage   = 6;
   shot->sprite   = SPR_SHOT_MGUN_L1;
   shot->dir      = o->dir;
   shot->shot.dir = dir;
@@ -201,7 +200,7 @@ void ai_curlyboss_shot(Object *o)
 {
   if (hitdetect(o, player) && !player->hurt_time)
   {
-    hurtplayer(o->shot.damage);
+    hurtplayer(6);
   }
   else if (IsBlockedInShotDir(o))
   {


### PR DESCRIPTION
Played around with the source and got this simple issue fixed. Can be tested with [this save file](https://www.cavestory.org/saves/02-011.zip).

I wondered whether it's better to define the damage (6) as a constant, but as this is a one-time usage and many other AI code also contains hard-coded damage values, I guess that's less of a problem.

Hope that helps ^ ^