### PR TITLE
Fix mushrooms do not follow slopes

### DIFF
--- a/src/ai/sand/curly_boss.cpp
+++ b/src/ai/sand/curly_boss.cpp
@@ -165,7 +165,6 @@ static void curlyboss_fire(Object *o, int dir)
 {
   Object *shot = SpawnObjectAtActionPoint(o, OBJ_CURLYBOSS_SHOT);
 
-  shot->damage   = 6;
   shot->sprite   = SPR_SHOT_MGUN_L1;
   shot->dir      = o->dir;
   shot->shot.dir = dir;
@@ -201,7 +200,7 @@ void ai_curlyboss_shot(Object *o)
 {
   if (hitdetect(o, player) && !player->hurt_time)
   {
-    hurtplayer(o->shot.damage);
+    hurtplayer(6);
   }
   else if (IsBlockedInShotDir(o))
   {

--- a/src/ai/village/village.cpp
+++ b/src/ai/village/village.cpp
@@ -129,6 +129,7 @@ void ai_mushroom_enemy(Object *o)
   switch (o->state)
   {
     case 0:
+      o->nxflags |= NXFLAG_FOLLOW_SLOPE;
       o->frame     = 0;
       o->animtimer = 0;
       o->xinertia  = 0;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1566,14 +1566,14 @@ void c------------------------------() {}
 // does the invincibility flash when the player has recently been hurt
 void PDoHurtFlash(void)
 {
-  // note that hurt_flash_state is NOT cleared when timer reaches 0,
-  // but this is ok because the number of blinks are and always should be even.
-  // (if not it wouldn't look right when he unhurts).
+  // note that hurt_flash_state needs to be kept updated
+  // because in TSC scripts it may be set to 0
+  // with the player's flash state staying at 1 (invisible)
   if (player->hurt_time)
   {
     player->hurt_time--;
-    player->hurt_flash_state = (player->hurt_time & 2);
   }
+  player->hurt_flash_state = (player->hurt_time & 2);
 }
 
 // decides which player frame to show


### PR DESCRIPTION
Mushrooms can get stuck in a pit.

<img width="241" alt="pit" src="https://user-images.githubusercontent.com/45892908/52521064-7c204f00-2cac-11e9-9d7a-8436f65aef13.png">

(There are extraneous commits due to conflict resolution, so maybe squash & merge…)