### PR TITLE
Fix mushrooms do not follow slopes

### DIFF
--- a/src/ai/village/village.cpp
+++ b/src/ai/village/village.cpp
@@ -129,6 +129,7 @@ void ai_mushroom_enemy(Object *o)
   switch (o->state)
   {
     case 0:
+      o->nxflags |= NXFLAG_FOLLOW_SLOPE;
       o->frame     = 0;
       o->animtimer = 0;
       o->xinertia  = 0;


### PR DESCRIPTION
(Duplicate of #105 due to source branch change, sorry)

Mushrooms can get stuck in a pit.

<img width="241" alt="pit" src="https://user-images.githubusercontent.com/45892908/52521064-7c204f00-2cac-11e9-9d7a-8436f65aef13.png">