### PR TITLE
Fix building by adding SDL_MIXER to include path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(SDL2_mixer REQUIRED)
 find_package(PNG REQUIRED)
 
 include_directories(${SDL2_INCLUDE_DIR})
+include_directories(${SDL_MIXER_INCLUDE_DIR})
 include_directories(${PNG_PNG_INCLUDE_DIR})
 include_directories("${nx_SOURCE_DIR}/deps")
 


### PR DESCRIPTION
I had some difficulties getting this to build on NixOS. NixOS has each package in a separate directory. I'm guessing  SDL_mixer is usually in the same directory as SDL2? CMake finds the SDL_mixer directory, but previously didn't add it to the g++ commandline. With this patch, it does.

Fix from:
NixOS/nixpkgs#64408