### PR TITLE
Fix buffer overflow for longer sound effects file name in Pixtone.

### DIFF
--- a/src/sound/Pixtone.cpp
+++ b/src/sound/Pixtone.cpp
@@ -274,7 +274,7 @@ bool Pixtone::init()
     wave[MOD_NOISE].table[i]   = (signed char)(seed >> 16) / 2;      // Pseudorandom
   }
 
-  char fname[80];
+  std::string fname;
   uint32_t slot;
 
   LOG_INFO("Loading Sound FX...");
@@ -282,10 +282,17 @@ bool Pixtone::init()
   std::string path = ResourceManager::getInstance()->getPathForDir("pxt/");
   for (slot = 1; slot <= NUM_SOUNDS; slot++)
   {
-    sprintf(fname, "%sfx%02x.pxt", path.c_str(), slot);
+    char hexid[3];
+
+    fname.clear();
+    fname += path;
+    fname += "fx";
+    sprintf(hexid, "%02x", slot);
+    fname += hexid;
+    fname += ".pxt";
     stPXSound snd;
 
-    if (!snd.load(fname))
+    if (!snd.load(fname.c_str()))
       continue;
     snd.render();
 


### PR DESCRIPTION
In Pixtone, the full path is assumed to be only 80 characters, which leads to longer filenames causing a buffer overflow, which manifests as a crash on game start. So, I've replaced the C string with a C++ string. (Unfortunately, sprintf doesn't seem to easily work with C++ strings, so I did a series of += instead.)

Fix from:
https://github.com/NixOS/nixpkgs/pull/64408