### PR TITLE
Fixed Switch links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,8 @@ ELSEIF(PLATFORM STREQUAL "switch")
       glapi
       drm_nouveau
       -lnx
-      -lopus
-      -lopusfile
+      opusfile
+      opus
     )
 
     add_nro_target(nx "NXEngine-evo" "NXEngine team" "${nx_VERSION_MAJOR}.${nx_VERSION_MINOR}.${nx_VERSION_RELEASE}" "${CMAKE_SOURCE_DIR}/platform/switch/icon.jpg" "${CMAKE_SOURCE_DIR}/release")


### PR DESCRIPTION
Original opus and file link order were creating undefined errors when building through devKitPro; this fixes it.