### PR TITLE
Add optional audio linear-interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ IF(LOW_END_HARDWARE)
 ENDIF()
 
 IF(RESAMPLER MATCHES "nearest")
-    # Nothing
+    # This is used if neither RESAMPLER_LINEAR
+    # nor DRESAMPLER_LANCZOS are defined
 ELSEIF(RESAMPLER MATCHES "linear")
     add_definitions(-DRESAMPLER_LINEAR)
 ELSEIF(RESAMPLER MATCHES "lanczos")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ ELSEIF(RESAMPLER MATCHES "linear")
     add_definitions(-DRESAMPLER_LINEAR)
 ELSEIF(RESAMPLER MATCHES "lanczos")
     add_definitions(-DRESAMPLER_LANCZOS)
+ELSE()
+	message(FATAL_ERROR "Invalid RESAMPLER selected")
 ENDIF()
 
 add_definitions("-Wall")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 
 option(LOW_END_HARDWARE "Build for low-end hardware" ON)
+set(RESAMPLER "nearest" CACHE STRING "Which algorithm to use for audio resampling: 'nearest' for nearest-neighbour (extremely fast, low-quality), 'linear' for linear-interpolation (fast, mid-quality), 'lanczos' for Lanczos filtering (slow, high-quality)")
 set(PLATFORM "pc" CACHE STRING "Platform to build for")
 set_property(CACHE PLATFORM PROPERTY STRINGS pc vita switch)
 
@@ -96,6 +97,14 @@ ENDIF()
 
 IF(LOW_END_HARDWARE)
     add_definitions(-D_LOW_END_HARDWARE)
+ENDIF()
+
+IF(RESAMPLER MATCHES "nearest")
+    # Nothing
+ELSEIF(RESAMPLER MATCHES "linear")
+    add_definitions(-DRESAMPLER_LINEAR)
+ELSEIF(RESAMPLER MATCHES "lanczos")
+    add_definitions(-DRESAMPLER_LANCZOS)
 ENDIF()
 
 add_definitions("-Wall")


### PR DESCRIPTION
Hello. For CSE2's audio resampler, I've always focussed on speed over quality, but I didn't want to use nearest-neighbour interpolation because of how badly it affects the song Gestation. Because of this, CSE2 has always used a linear-interpolator.

Recently I began looking into Lanczos resampling - the same thing this project uses. However, despite how much more complex the algorithm is, I couldn't hear a noticeable difference in audio quality.

This has me wondering if Lanczos is actually worth it: I noticed the algorithm is so slow that you had to disable it on all platforms in 8f8fd53d94105964fef05cd487a22bb4243c6708.

I really dislike how nearest-neighbour sounds, so I figured I'd add a linear-interpolator to your engine. It should hopefully strike a good balance between performance and quality.

Both this and the Lanczos resampler are still disabled by default, but they can be enabled via a CMake option.