### PR TITLE
Add wget to cavestory-extract's build-packages

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -64,6 +64,7 @@ parts:
     build-packages:
       - jq
       - unzip
+      - wget
     override-build: |
       # Extract and install data
       export APP_ID="org.nxengine.nxengine_evo"


### PR DESCRIPTION
This is needed for the automated snap builds because it seems like `wget` is not installed by default in the launchpad builders' LXC image.
Strangely, it seems to be available in the multipass VMs that snapcraft uses by default which is why I didn't notice this previously.