### PR TITLE
Only support the snap for amd64 for now

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -5,6 +5,9 @@ adopt-info: metadata
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: [amd64]
+
 apps:
   nxengine-evo:
     command: usr/local/bin/nxengine-evo


### PR DESCRIPTION
`x86_64` / `amd64` is the only architecture I can reasonably test the snap on at the moment. Of course, if someone steps up to test and prepare snap releases on other architectures, we can add those other architectures to the supported list.