### PR TITLE
Giant Pignons jump towards the player upon getting hit

### DIFF
--- a/src/ai/village/village.cpp
+++ b/src/ai/village/village.cpp
@@ -204,6 +204,12 @@ void ai_mushroom_enemy(Object *o)
     o->state    = SHOT;
     o->yinertia = -0x200;
     o->frame    = 6;
+    //Giant Pignons jump towards the player upon getting hit
+    //Normal Pignons keep their current x velocity
+    if (o->type == OBJ_GIANT_MUSHROOM_ENEMY)
+    {
+      o->xinertia = (player->x > o->x) ? 0x100 : -0x100;
+    }
   }
 
   o->yinertia += 0x40;


### PR DESCRIPTION
In original cave story, Giant Pignons jump towards the player after getting hit, but small pignons just preserve their current velocity. nxengine up until now applied the small pignon behavior universally. This just restores the original behavior

Original behavior:

https://user-images.githubusercontent.com/47910150/104820712-643c9880-57fc-11eb-89b3-66a88a7986eb.mp4

NXEngine:

https://user-images.githubusercontent.com/47910150/104820733-7ddde000-57fc-11eb-9d9d-b999edb1f19c.mp4

Fixed NXEngine:

https://user-images.githubusercontent.com/47910150/104820740-9221dd00-57fc-11eb-9a48-9386befe9011.mp4

