### PR TITLE
Fix large wait time in between Igor's mouth blasts and next attack

### DIFF
--- a/src/ai/egg/igor.cpp
+++ b/src/ai/egg/igor.cpp
@@ -285,8 +285,7 @@ void ai_boss_igor(Object *o)
 
         if (o->timer > 132) // fires 6 shots
         {
-          o->state = STATE_BEGIN_ATTACK;
-          o->timer = 0;
+          o->state = STATE_INIT;
         }
       }
     }

--- a/src/ai/egg/igor.cpp
+++ b/src/ai/egg/igor.cpp
@@ -285,7 +285,7 @@ void ai_boss_igor(Object *o)
 
         if (o->timer > 132) // fires 6 shots
         {
-          o->state = STATE_INIT;
+          o->state = STATE_BEGIN_ATTACK;
           o->timer = 0;
         }
       }


### PR DESCRIPTION
Fixes #207. It feels counter-intuitive, but I'm _fairly_ confident that this is the approach the game used, or at the very least, accurately replicates the timing of the boss fight with no discernible side-effects. 

If STATE_MOUTH_BLAST_2 goes to STATE_INIT instead, as it did previously, Igor has to sit in STATE_STAND a full second before he can try attacking again. Messing with any of the logic in STATE_STAND seems like a bad idea, since it also is called in between punches. Going straight from STATE_MOUTH_BLAST_2 to STATE_BEGIN_ATTACK seems like the best approach to the accuracy.