### PR TITLE
cmake install improvments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,9 @@ add_definitions("-Wall")
 add_executable(nx ${SOURCES})
 
 IF(PLATFORM STREQUAL "pc")
-set_property(TARGET nx PROPERTY OUTPUT_NAME nxengine-evo)
+    set_property(TARGET nx PROPERTY OUTPUT_NAME nxengine-evo)
     add_definitions("-std=c++11")
+    add_definitions(-DDATADIR="${CMAKE_INSTALL_FULL_DATADIR}/nxengine/data/")
     target_link_libraries(nx ${SDL2_LIBRARY} ${SDL2_MIXER_LIBRARY} ${SDL2_IMAGE_LIBRARY} ${PNG_LIBRARY} ${JPEG_LIBRARY})
 
 ELSEIF(PLATFORM STREQUAL "vita")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ set (nx_APP_ID org.nxengine.nxengine_evo)
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 
-
 find_package(SDL2 REQUIRED)
 find_package(SDL2_mixer REQUIRED)
 find_package(SDL2_image REQUIRED)
@@ -195,10 +194,8 @@ IF(PLATFORM STREQUAL "pc")
 
     # Install XDG metadata on Desktop Linux like platforms
     IF(UNIX AND NOT APPLE AND NOT ANDROID)
-        install(FILES platform/xdg/${nx_APP_ID}.desktop     DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-        install(FILES platform/xdg/${nx_APP_ID}.png         DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps)
-        install(FILES platform/xdg/${nx_APP_ID}.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+        install(FILES platform/xdg/${nx_APP_ID}.desktop     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+        install(FILES platform/xdg/${nx_APP_ID}.png         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps)
+        install(FILES platform/xdg/${nx_APP_ID}.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
     ENDIF()
 ENDIF()
-
-

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -75,6 +75,10 @@ std::string ResourceManager::getLocalizedPath(const std::string &filename)
 #if defined(__linux__)
   char *home = getenv("HOME");
 
+#if defined(DATADIR)
+  std::string _data (DATADIR);
+#endif
+
   if (home != NULL)
   {
     if (!_mod.empty())
@@ -88,23 +92,34 @@ std::string ResourceManager::getLocalizedPath(const std::string &filename)
 
   if (!_mod.empty())
   {
+#if defined(DATADIR)
+    _paths.push_back(_data + "mods/" + _mod + "/lang/" + std::string(settings->language) + "/" + filename);
+    _paths.push_back(_data + "mods/" + _mod + "/" + filename);
+#else
+    _paths.push_back("/usr/local/share/nxengine/data/mods/" + _mod + "/lang/" + std::string(settings->language) + "/" + filename);
+    _paths.push_back("/usr/local/share/nxengine/data/mods/" + _mod + "/" + filename)
+
     _paths.push_back("/usr/share/nxengine/data/mods/" + _mod + "/lang/" + std::string(settings->language) + "/" + filename);
     _paths.push_back("/usr/share/nxengine/data/mods/" + _mod + "/" + filename);
 
-    _paths.push_back("/usr/local/share/nxengine/data/mods/" + _mod + "/lang/" + std::string(settings->language) + "/" + filename);
-    _paths.push_back("/usr/local/share/nxengine/data/mods/" + _mod + "/" + filename);
-
     _paths.push_back("../share/nxengine/data/mods/" + _mod + "/lang/" + std::string(settings->language) + "/" + filename);
     _paths.push_back("../share/nxengine/data/mods/" + _mod + "/" + filename);
+#endif
   }
-  _paths.push_back("/usr/share/nxengine/data/lang/" + std::string(settings->language) + "/" + filename);
-  _paths.push_back("/usr/share/nxengine/data/" + filename);
 
+#if defined(DATADIR)
+  _paths.push_back(_data + "lang/" + std::string(settings->language) + "/" + filename);
+  _paths.push_back(_data + filename);
+#else
   _paths.push_back("/usr/local/share/nxengine/data/lang/" + std::string(settings->language) + "/" + filename);
   _paths.push_back("/usr/local/share/nxengine/data/" + filename);
 
+  _paths.push_back("/usr/share/nxengine/data/lang/" + std::string(settings->language) + "/" + filename);
+  _paths.push_back("/usr/share/nxengine/data/" + filename);
+
   _paths.push_back("../share/nxengine/data/lang/" + std::string(settings->language) + "/" + filename);
   _paths.push_back("../share/nxengine/data/" + filename);
+#endif
 
 #elif defined(__APPLE__)
   char *home = SDL_GetPrefPath("nxengine", "nxengine-evo");
@@ -191,6 +206,10 @@ std::string ResourceManager::getPathForDir(const std::string &dir)
 {
   std::vector<std::string> _paths;
 
+#if defined(DATADIR)
+  std::string _data (DATADIR);
+#endif
+
 #if defined(__linux__)
   char *home = getenv("HOME");
   if (home != NULL)
@@ -202,14 +221,22 @@ std::string ResourceManager::getPathForDir(const std::string &dir)
 
   if (!_mod.empty())
   {
-    _paths.push_back("/usr/share/nxengine/data/mods/" + _mod + "/" + dir);
+#if defined(DATADIR)
+    _paths.push_back(_data + "mods/" + _mod + "/" + dir);
+#else
     _paths.push_back("/usr/local/share/nxengine/data/mods/" + _mod + "/" + dir);
+    _paths.push_back("/usr/share/nxengine/data/mods/" + _mod + "/" + dir);
     _paths.push_back("../share/nxengine/data/mods/" + _mod + "/" + dir);
+#endif
   }
 
-  _paths.push_back("/usr/share/nxengine/data/" + dir);
+#if defined(DATADIR)
+  _paths.push_back(_data + dir);
+#else
   _paths.push_back("/usr/local/share/nxengine/data/" + dir);
+  _paths.push_back("/usr/share/nxengine/data/" + dir);
   _paths.push_back("../share/nxengine/data/" + dir);
+#endif
 
 #elif defined(__APPLE__)
   char *home = SDL_GetPrefPath("nxengine", "nxengine-evo");


### PR DESCRIPTION
This PR has two related install fixes that can help distros.

* GNU install standards state that `datadir` should be used for program specific data and `datarootdir` should be used for other data files such as icons or desktop files. However nxengine-evo installs everything to `CMAKE_INSTALL_DATADIR`. I changed the non-game data to use `CMAKE_INSTALL_DATAROOTDIR` instead. By default `CMAKE_INSTALL_DATADIR` sources the value of `CMAKE_INSTALL_DATAROOTDIR`, but its important to be able to install them into separate locations.
* For pc builds this adds a `DATADIR` define to indicate the locations of the data files, it uses the value of `${CMAKE_INSTALL_FULL_DATADIR}/nxengine/data/`. This allows the user to install nxengine-evo to arbitrary locations. For example `/usr/share/games/nxengine` or even `$HOME/games/nxengine`.