### PR TITLE
Ensure DATADIR is only used with __linux__.

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -206,12 +206,13 @@ std::string ResourceManager::getPathForDir(const std::string &dir)
 {
   std::vector<std::string> _paths;
 
+#if defined(__linux__)
+  char *home = getenv("HOME");
+
 #if defined(DATADIR)
   std::string _data (DATADIR);
 #endif
 
-#if defined(__linux__)
-  char *home = getenv("HOME");
   if (home != NULL)
   {
     if (!_mod.empty())


### PR DESCRIPTION
Fixes a minor nit I noticed from PR https://github.com/nxengine/nxengine-evo/pull/209.

The other check is already like this.

https://github.com/nxengine/nxengine-evo/blob/389e371700e67b77f8eb87cd2d0bc91578730b12/src/ResourceManager.cpp#L75