### PR TITLE
Add chat badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NXEngine-evo
 A somewhat upgraded/refactored version of [NXEngine](http://nxengine.sourceforge.net/) by Caitlin Shaw.
 
-[![Build Status](https://travis-ci.org/nxengine/nxengine-evo.svg?branch=master)](https://travis-ci.org/nxengine/nxengine-evo) [![Discord chat](https://img.shields.io/discord/804396136252964954?label=Discord)](https://discord.gg/jnwmA7DhQh) [![Matrix chat](https://img.shields.io/matrix/nxengine-evo:ninetailed.ninja?server_fqdn=matrix.ninetailed.ninja&label=Matrix)](https://matrix.to/#/#nxengine-evo:ninetailed.ninja)
+[![Discord chat](https://img.shields.io/discord/804396136252964954?label=Discord)](https://discord.gg/jnwmA7DhQh) [![Matrix chat](https://img.shields.io/matrix/nxengine-evo:ninetailed.ninja?server_fqdn=matrix.ninetailed.ninja&label=Matrix)](https://matrix.to/#/#nxengine-evo:ninetailed.ninja)
 
 ![Screenshot](https://raw.githubusercontent.com/nxengine/nxengine-evo/master/screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NXEngine-evo
 A somewhat upgraded/refactored version of [NXEngine](http://nxengine.sourceforge.net/) by Caitlin Shaw.
 
-[![Build Status](https://travis-ci.org/nxengine/nxengine-evo.svg?branch=master)](https://travis-ci.org/nxengine/nxengine-evo) [![Build status](https://ci.appveyor.com/api/projects/status/85orsvsorwbvct25?svg=true)](https://ci.appveyor.com/project/nxengine/nxengine-evo/branch/master)
+[![Build Status](https://travis-ci.org/nxengine/nxengine-evo.svg?branch=master)](https://travis-ci.org/nxengine/nxengine-evo) [![Discord chat](https://img.shields.io/discord/804396136252964954?label=Discord)](https://discord.gg/jnwmA7DhQh) [![Matrix chat](https://img.shields.io/matrix/nxengine-evo:ninetailed.ninja?server_fqdn=matrix.ninetailed.ninja&label=Matrix)](https://matrix.to/#/#nxengine-evo:ninetailed.ninja)
 
 ![Screenshot](https://raw.githubusercontent.com/nxengine/nxengine-evo/master/screenshot.png)
 


### PR DESCRIPTION
Matrix badge should start working once I manage to workaround old [matrix-appservice-irc bug](https://github.com/matrix-org/matrix-appservice-irc/issues/408) and can set the room's history to public (rather than members only) 🤮

fixes #215