### PR TITLE
Don't reset the spur on level changes

### DIFF
--- a/src/p_arms.cpp
+++ b/src/p_arms.cpp
@@ -88,14 +88,9 @@ BulletInfo bullet_table[] = {
 
     {0, 0, 0, 0, 0, 0, 0, 0, NXE::Sound::SFX::SND_NULL}};
 
-// resets anything like charging states etc on player re-init (Player::Init)
+// resets weapons on player re-init (Player::Init)
 void PResetWeapons()
 {
-  Weapon *spur      = &player->weapons[WPN_SPUR];
-  spur->chargetimer = 0;
-  spur->level       = 0;
-  spur->xp          = 0;
-
   init_whimstar(&player->whimstar);
 }
 


### PR DESCRIPTION
This *seems* like the right fix to me, but I'm not sure of the consequences of never resetting the spur at the start of a level or why it was added here in the first place.

I know from my testing that this fixes #229 and everything seems to be working normally.