### PR TITLE
Fix off by one error in weapon leveling

### DIFF
--- a/src/playerstats.cpp
+++ b/src/playerstats.cpp
@@ -25,7 +25,7 @@ void AddXP(int xp, bool quiet)
   weapon->xp += xp;
 
   // leveling up...
-  while (weapon->xp > weapon->max_xp[weapon->level])
+  while (weapon->xp >= weapon->max_xp[weapon->level])
   {
     if (weapon->level < 2)
     {


### PR DESCRIPTION
The weapon should level up when the experience equals the max for that
level. For example, the polar star levels up from lvl 1 to 2 at 10
experience. We want to trigger the level up when we reach exactly 10
experience.

See #141