### PR TITLE
Fix Toroko's title screen sprite

### DIFF
--- a/src/intro/title.cpp
+++ b/src/intro/title.cpp
@@ -27,7 +27,7 @@ static struct
 } titlescreens[] = {
     {(3 * 3000), SPR_SUE, {2,3,4,5}, 2, 14},     // 3 mins	- Sue & Safety
     {(4 * 3000), SPR_KING, {4,5,6,7}, 41, 13},   // 4 mins	- King & White
-    {(5 * 3000), SPR_TOROKO, {1,2,3,4}, 40, 12}, // 5 mins	- Toroko & Toroko's Theme
+    {(5 * 3000), SPR_TOROKO_SHACK, {1,2,3,2}, 40, 12}, // 5 mins	- Toroko & Toroko's Theme
     {(6 * 3000), SPR_CURLY, {0,1,2,3}, 36, 10},  // 6 mins	- Curly & Running Hell
     {0xFFFFFFFF, SPR_MYCHAR, {0,1,0,2}, 24, 9}   // default
 };


### PR DESCRIPTION
The Toroko sprite on the title screen for when your 290 time is 4 to 5
minutes is wrong. It uses the "Toroko running" animation instead of the
"Toroko carrying a fishing pole" animation. It was actually correct in
NXEngine 1.0.0.6 and nxengine-evo until 1dd99c5c. The problematic change
in that commit is here is here:

```diff
-    {(3 * 3000), SPR_CS_SUE, 2, 14},     // 3 mins	- Sue & Safety
-    {(4 * 3000), SPR_CS_KING, 41, 13},   // 4 mins	- King & White
-    {(5 * 3000), SPR_CS_TOROKO, 40, 12}, // 5 mins	- Toroko & Toroko's Theme
-    {(6 * 3000), SPR_CS_CURLY, 36, 10},  // 6 mins	- Curly & Running Hell
-    {0xFFFFFFFF, SPR_CS_MYCHAR, 24, 9}   // default
+    {(3 * 3000), SPR_SUE, {2,3,4,5}, 2, 14},     // 3 mins	- Sue & Safety
+    {(4 * 3000), SPR_KING, {4,5,6,7}, 41, 13},   // 4 mins	- King & White
+    {(5 * 3000), SPR_TOROKO, {1,2,3,4}, 40, 12}, // 5 mins	- Toroko & Toroko's Theme
+    {(6 * 3000), SPR_CURLY, {0,1,2,3}, 36, 10},  // 6 mins	- Curly & Running Hell
+    {0xFFFFFFFF, SPR_MYCHAR, {0,1,0,2}, 24, 9}   // default
```

The SPR_CS_TOROKO sprite actually looks like `SPR_TOROKO_SHACK
{1,2,3,2}`, not `SPR_TOROKO {1,2,3,4}`. If I understand correctly, the
sprites changed from the SPR_CS_* to SPR_* variants because the new ones
can face either direction. I tested with RTL enabled and it looks like
it works with both LTR and RTL.

---

Original Cave Story:

![cave story - Toroko title](https://user-images.githubusercontent.com/2390950/131363391-87462770-2160-42be-b5bb-9068be9979c8.png)

nxengine-evo:

![image](https://user-images.githubusercontent.com/2390950/131363533-cc35cfe1-1358-4ddc-bf0a-477d06db1e3e.png)