### PR TITLE
Make presses able to fall more than once

### DIFF
--- a/src/ai/sym/sym.cpp
+++ b/src/ai/sym/sym.cpp
@@ -790,7 +790,7 @@ void ai_press(Object *o)
         SmokeSide(o, 4, DOWN);
         quake(10);
 
-        o->state  = 11;
+        o->state  = 0;
         o->frame  = 0;
         o->damage = 0;
         o->flags |= FLAG_SOLID_BRICK;


### PR DESCRIPTION
Previously, after a press fell the first time it would stop forever. If
you broke the block under it, it would stay floating in midair. Now it
resets to the waiting state after hitting the ground.

Before:

![nxengine-stuck-press](https://user-images.githubusercontent.com/2390950/131855963-69abb9b7-43f3-4b49-ae81-dc896dbb69d4.png)

After:

![unstuck-presses](https://user-images.githubusercontent.com/2390950/131855821-c83e1443-6de5-4bfd-9c62-ca22b7abc364.gif)

See #224