### PR TITLE
Add support for older Ubuntu releases to the AppImage

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,113 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+AppDir:
+  path: build/AppDir
+  app_info:
+    id: !ENV ${APP_ID}
+    name: Cave Story (NXEngine Evo)
+    icon: org.nxengine.nxengine_evo
+    version: !ENV ${APP_VERSION}
+    exec: usr/bin/nxengine-evo
+    exec_args: $@
+  apt:
+    arch:
+    - amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal main restricted
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main restricted
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal universe
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal-updates universe
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal multiverse
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal-updates multiverse
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ focal-backports main restricted
+        universe multiverse
+    - sourceline: deb http://security.ubuntu.com/ubuntu focal-security main restricted
+    - sourceline: deb http://security.ubuntu.com/ubuntu focal-security universe
+    - sourceline: deb http://security.ubuntu.com/ubuntu focal-security multiverse
+    include:
+    - libgpg-error0:amd64
+    - liblzma5:amd64
+    - libpcre3:amd64
+    - libpulse0:amd64
+    - libreadline8:amd64
+    - libsystemd0:amd64
+    - libudev1:amd64
+  files:
+    include:
+    - /lib/libopusfile.so.0
+    - /lib/x86_64-linux-gnu/libFLAC.so.8
+    - /lib/x86_64-linux-gnu/libGLX.so.0
+    - /lib/x86_64-linux-gnu/libGLdispatch.so.0
+    - /lib/x86_64-linux-gnu/libLLVM-12.so.1
+    - /lib/x86_64-linux-gnu/libSDL2-2.0.so.0
+    - /lib/x86_64-linux-gnu/libSDL2_image-2.0.so.0
+    - /lib/x86_64-linux-gnu/libSDL2_mixer-2.0.so.0
+    - /lib/x86_64-linux-gnu/libX11.so.6
+    - /lib/x86_64-linux-gnu/libXau.so.6
+    - /lib/x86_64-linux-gnu/libXcursor.so.1
+    - /lib/x86_64-linux-gnu/libXdmcp.so.6
+    - /lib/x86_64-linux-gnu/libXext.so.6
+    - /lib/x86_64-linux-gnu/libXfixes.so.3
+    - /lib/x86_64-linux-gnu/libXi.so.6
+    - /lib/x86_64-linux-gnu/libXinerama.so.1
+    - /lib/x86_64-linux-gnu/libXrandr.so.2
+    - /lib/x86_64-linux-gnu/libXrender.so.1
+    - /lib/x86_64-linux-gnu/libXss.so.1
+    - /lib/x86_64-linux-gnu/libXxf86vm.so.1
+    - /lib/x86_64-linux-gnu/libapparmor.so.1
+    - /lib/x86_64-linux-gnu/libasound.so.2
+    - /lib/x86_64-linux-gnu/libasyncns.so.0
+    - /lib/x86_64-linux-gnu/libbsd.so.0
+    - /lib/x86_64-linux-gnu/libedit.so.2
+    - /lib/x86_64-linux-gnu/libelf.so.1
+    - /lib/x86_64-linux-gnu/libffi.so.7
+    - /lib/x86_64-linux-gnu/libfluidsynth.so.2
+    - /lib/x86_64-linux-gnu/libgcrypt.so.20
+    - /lib/x86_64-linux-gnu/libglapi.so.0
+    - /lib/x86_64-linux-gnu/libglib-2.0.so.0
+    - /lib/x86_64-linux-gnu/libgmodule-2.0.so.0
+    - /lib/x86_64-linux-gnu/libgobject-2.0.so.0
+    - /lib/x86_64-linux-gnu/libinstpatch-1.0.so.2
+    - /lib/x86_64-linux-gnu/libjack.so.0
+    - /lib/x86_64-linux-gnu/libjbig.so.0
+    - /lib/x86_64-linux-gnu/libjpeg.so.8
+    - /lib/x86_64-linux-gnu/liblz4.so.1
+    - /lib/x86_64-linux-gnu/libmodplug.so.1
+    - /lib/x86_64-linux-gnu/libmpg123.so.0
+    - /lib/x86_64-linux-gnu/libogg.so.0
+    - /lib/x86_64-linux-gnu/libopus.so.0
+    - /lib/x86_64-linux-gnu/libpng16.so.16
+    - /lib/x86_64-linux-gnu/libpulse-simple.so.0
+    - /lib/x86_64-linux-gnu/libpulse.so.0
+    - /lib/x86_64-linux-gnu/libsensors.so.5
+    - /lib/x86_64-linux-gnu/libsndfile.so.1
+    - /lib/x86_64-linux-gnu/libstdc++.so.6
+    - /lib/x86_64-linux-gnu/libtiff.so.5
+    - /lib/x86_64-linux-gnu/libvorbis.so.0
+    - /lib/x86_64-linux-gnu/libvorbisenc.so.2
+    - /lib/x86_64-linux-gnu/libvorbisfile.so.3
+    - /lib/x86_64-linux-gnu/libvulkan.so.1
+    - /lib/x86_64-linux-gnu/libwayland-client.so.0
+    - /lib/x86_64-linux-gnu/libwayland-cursor.so.0
+    - /lib/x86_64-linux-gnu/libwayland-egl.so.1
+    - /lib/x86_64-linux-gnu/libwebp.so.6
+    - /lib/x86_64-linux-gnu/libwrap.so.0
+    - /lib/x86_64-linux-gnu/libxcb-dri2.so.0
+    - /lib/x86_64-linux-gnu/libxcb-dri3.so.0
+    - /lib/x86_64-linux-gnu/libxcb-present.so.0
+    - /lib/x86_64-linux-gnu/libxcb-sync.so.1
+    - /lib/x86_64-linux-gnu/libxkbcommon.so.0
+    - /lib/x86_64-linux-gnu/libxshmfence.so.1
+    - /lib/x86_64-linux-gnu/libzstd.so.1
+    - /usr/lib/locale/locale-archive
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
+AppImage:
+  arch: !ENV ${PLATFORM_SUFFIX}
+  file_name: !ENV '${OUTPUT}'
+  update-information: None

--- a/build-scripts/build-appimage.sh
+++ b/build-scripts/build-appimage.sh
@@ -20,12 +20,12 @@ then
 fi
 
 # Extract latest release from AppStream data
-VERSION="v$(xmllint --xpath 'string(/component/releases/release/@version)' "platform/xdg/${APP_ID}.appdata.xml")"
+APP_VERSION="v$(xmllint --xpath 'string(/component/releases/release/@version)' "platform/xdg/${APP_ID}.appdata.xml")"
 
 # override for CI
 if [ "${APPVEYOR_REPO_TAG:-}" == "true" ]
 then
-    VERSION="${APPVEYOR_REPO_TAG_NAME}"
+    APP_VERSION="${APPVEYOR_REPO_TAG_NAME}"
 fi
 
 MACHINE="$(uname -m)"
@@ -33,9 +33,9 @@ MACHINE="$(uname -m)"
 # Download required dependencies
 build-scripts/utils/common.download-extern.sh
 
-# Additionally download recent version of the LinuxDeploy AppImage utility (no checksum verification since file regularily changes when updated to newer versions)
-test -e "extern/linuxdeploy.AppImage" || wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${MACHINE}.AppImage" -O "extern/linuxdeploy.AppImage"
-chmod +x extern/linuxdeploy.AppImage
+# Additionally download recent version of the appimage-builder AppImage utility (no checksum verification since file regularily changes when updated to newer versions)
+test -e "extern/appimage-builder.AppImage" || wget "https://github.com/AppImageCrafters/appimage-builder/releases/download/Continuous/appimage-builder-0.9.1-cd0ec34-x86_64.AppImage" -O "extern/appimage-builder.AppImage"
+chmod +x extern/appimage-builder.AppImage
 
 # Build NXEngine-Evo
 if ! ${SKIP_BUILD};
@@ -46,6 +46,7 @@ then
 fi
 
 # Generate AppImage filesystem image directory
+rm -rf AppDir
 DESTDIR=AppDir ninja -Cbuild install
 build-scripts/utils/common.install-extern.sh build/AppDir/usr/share/nxengine build/nxextract
 
@@ -64,11 +65,9 @@ case "${MACHINE}" in
 	;;
 esac
 
-export VERSION
-export OUTPUT="NXEngine-Evo-${VERSION}-Linux-${PLATFORM_SUFFIX}.AppImage"
+export APP_VERSION
+export PLATFORM_SUFFIX
+export OUTPUT="NXEngine-Evo-${APP_VERSION}-Linux-${PLATFORM_SUFFIX}.AppImage"
 rm -f "${OUTPUT}"
-extern/linuxdeploy.AppImage \
-	--appdir=build/AppDir \
-	--desktop-file="platform/xdg/${APP_ID}.desktop" \
-	--icon-file="platform/xdg/${APP_ID}.png" \
-	--output=appimage
+
+extern/appimage-builder.AppImage


### PR DESCRIPTION
The oldest supported Ubuntu release is 18.04, so we should build the
AppImage with that version.

Fixes #237