### PR TITLE
Switch to a stable release of appimage-builder

### DIFF
--- a/build-scripts/build-appimage.sh
+++ b/build-scripts/build-appimage.sh
@@ -34,7 +34,7 @@ MACHINE="$(uname -m)"
 build-scripts/utils/common.download-extern.sh
 
 # Additionally download recent version of the appimage-builder AppImage utility (no checksum verification since file regularily changes when updated to newer versions)
-test -e "extern/appimage-builder.AppImage" || wget "https://github.com/AppImageCrafters/appimage-builder/releases/download/Continuous/appimage-builder-0.9.1-cd0ec34-x86_64.AppImage" -O "extern/appimage-builder.AppImage"
+test -e "extern/appimage-builder.AppImage" || wget "https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.9.2/appimage-builder-0.9.2-35e3eab-x86_64.AppImage" -O "extern/appimage-builder.AppImage"
 chmod +x extern/appimage-builder.AppImage
 
 # Build NXEngine-Evo


### PR DESCRIPTION
The download URL of the continuous build changes whenever there is a
release so we can't count on it. The maintainer released version 0.9.2
today that fixes bugs that I ran into on version 0.9.1, so we can use
the stable release now.