### PR TITLE
Undead Core Tweaks

### DIFF
--- a/src/ai/boss/undead_core.cpp
+++ b/src/ai/boss/undead_core.cpp
@@ -96,6 +96,9 @@ void c------------------------------() {}
 
 void UDCoreBoss::OnMapEntry()
 {
+  // Return if we already defeated UDCore
+  if (game.switchstage.eventonentry == 600) return;
+
   Object *o;
 
   // main object

--- a/src/ai/boss/undead_core.cpp
+++ b/src/ai/boss/undead_core.cpp
@@ -31,6 +31,7 @@ static struct
 
 enum CORE_STATES
 {
+  CR_LastBox    = 15, // scripted
   CR_FightBegin = 20, // scripted
   CR_FaceClosed = 200,
   CR_FaceSkull  = 210,
@@ -171,6 +172,16 @@ void UDCoreBoss::Run(void)
 
   switch (o->state)
   {
+    // last text box (scripted)
+    case CR_LastBox:
+    {
+      // set to invalid state so we don't run this again
+      o->state = 0;
+      face->state = FC_Skull;
+      SpawnFaceSmoke();
+    }
+    break;
+
     // fight begin (scripted)
     case CR_FightBegin:
     {

--- a/src/ai/boss/undead_core.cpp
+++ b/src/ai/boss/undead_core.cpp
@@ -461,7 +461,7 @@ bool UDCoreBoss::RunDefeated()
       o->yinertia = 0;
 
       face->state  = FC_Closed;
-      front->frame = 0; // front closed
+      front->frame = 2; // front closed
       back->frame  = 0; // not flashing
       SetRotatorStates(RT_Spin_Slow_Closed);
 


### PR DESCRIPTION
This fixes the Undead Core inconsistencies mentioned in #143.
Those being:
> * Undead Core should open when the last message box is active.
> * Undead Core should be closed (not open and empty) in its ending animation.
> * Undead Core should disappear after the fight.

The only thing I don't know is whether or not `game.switchstage.eventonentry` is always 600 when the cutscene returns to the Black Space after defeating the Undead Core.