### PR TITLE
Make Fire Whirr animation more like CS

### DIFF
--- a/src/ai/maze/labyrinth_m.cpp
+++ b/src/ai/maze/labyrinth_m.cpp
@@ -55,7 +55,18 @@ void ai_firewhirr(Object *o)
     case 10:
       o->frame ^= 1;
 
-      o->yinertia += (o->y < o->ymark) ? 0x10 : -0x10;
+      if (o->y <= o->ymark - CSFI * 12)
+      {
+        o->yinertia = 0x10;
+      }
+      else if (o->y > o->ymark + CSFI * 12)
+      {
+        o->yinertia = -0x10;
+      }
+      else
+      {
+        o->yinertia += (o->y < o->ymark) ? 0x10 : -0x10;
+      }
       LIMITY(0x200);
 
       // inc time-to-fire while player near


### PR DESCRIPTION
After staring at my screen with Cave Story and NXEngine-evo side by side for a while I was able to make the Fire Whirr animation in NXEngine-evo more like how it is in Cave Story based on pixel measurements from the first Fire Whirr in Labyrinth M.

Another way that almost works is to change `LIMITY` from 0x200 (512) to 432-448, but that seems to make the Fire Whirr go too slow.

Closes #137