### PR TITLE
Fix off-by-one error segfault

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -806,7 +806,7 @@ bool DebugConsole::Execute(std::string& line)
 
   // record command in backbuffer
   if (!fBackBuffer.empty())
-    fBackBuffer.erase(fBackBuffer.end());
+    fBackBuffer.erase(fBackBuffer.end() - 1);
   if (fBackBuffer.size() >= CONSOLE_MAX_BACK)
     fBackBuffer.erase(fBackBuffer.begin());
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -806,7 +806,7 @@ bool DebugConsole::Execute(std::string& line)
 
   // record command in backbuffer
   if (!fBackBuffer.empty())
-    fBackBuffer.erase(fBackBuffer.end() - 1);
+    fBackBuffer.pop_back();
   if (fBackBuffer.size() >= CONSOLE_MAX_BACK)
     fBackBuffer.erase(fBackBuffer.begin());
 


### PR DESCRIPTION
nxengine-evo was sefaulting on my M1 mac because of this error. I assume this code was meant to remove the last element from the `vector`.

After this change, everything appears to work fine.