### PR TITLE
Added 1280x720 resolution

### DIFF
--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -227,6 +227,7 @@ const Graphics::gres_t *Renderer::getResolutions(bool full_list)
          // widescreen
          {(char *)"480x272", 480, 272, 480, 272, 1, true, true},
          {(char *)"1024x600", 1024, 600, 512, 300, 2, true, true},
+         {(char *)"1280x720", 1280, 720, 427, 240, 3, true, true},
          {(char *)"1360x768", 1360, 768, 454, 256, 3, true, true},
          {(char *)"1366x768", 1366, 768, 455, 256, 3, true, true},
          {(char *)"1440x900", 1440, 900, 480, 300, 3, true, true},


### PR DESCRIPTION
This is a super tiny change that makes 1280x720 resolution available. I intended to play Cave Story Evo on my GPD Win, but found out that I could not choose its native resolution.

I tested briefly, it seems to work well.