### PR TITLE
fix crash in profile loading

### DIFF
--- a/src/common/misc.cpp
+++ b/src/common/misc.cpp
@@ -20,15 +20,25 @@
 uint16_t fgeti(FILE *fp)
 {
   uint16_t value;
-  fread(&value, 2, 1, fp);
-  return value;
+  if (fread(&value, 2, 1, fp) != 1) {
+    LOG_ERROR("fgeti: error reading uint16_t from file");
+    fclose(fp);
+    exit(1);
+  } else {
+    return value;
+  }
 }
 
 uint32_t fgetl(FILE *fp)
 {
   uint32_t value;
-  fread(&value, 4, 1, fp);
-  return value;
+   if (fread(&value, 4, 1, fp) != 1) {
+     LOG_ERROR("fgetl: error reading uint32_t from file");
+     fclose(fp);
+     exit(1);
+   } else {
+     return value;
+   }
 }
 
 void fputi(uint16_t word, FILE *fp)
@@ -44,19 +54,29 @@ void fputl(uint32_t word, FILE *fp)
 uint16_t fgeti(FILE *fp)
 {
   uint16_t a, b;
-  a = fgetc(fp);
-  b = fgetc(fp);
+  if ((a = fgetc(fp)) == EOF) goto error;
+  if ((b = fgetc(fp)) == EOF) goto error;
   return (b << 8) | a;
+
+error:
+  LOG_ERROR("fgeti: error reading uint16_t from file");
+  fclose(fp);
+  exit(1);
 }
 
 uint32_t fgetl(FILE *fp)
 {
   uint32_t a, b, c, d;
-  a = fgetc(fp);
-  b = fgetc(fp);
-  c = fgetc(fp);
-  d = fgetc(fp);
+  if ((a = fgetc(fp)) == EOF) goto error;
+  if ((b = fgetc(fp)) == EOF) goto error;
+  if ((c = fgetc(fp)) == EOF) goto error;
+  if ((d = fgetc(fp)) == EOF) goto error;
   return (d << 24) | (c << 16) | (b << 8) | (a);
+
+error:
+  LOG_ERROR("fgetl: error reading uint32_t from file");
+  fclose(fp);
+  exit(1);
 }
 
 void fputi(uint16_t word, FILE *fp)

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -69,6 +69,12 @@ bool profile_load(const char *pfname, Profile *file)
     int type = fgetl(fp);
     if (!type)
       break;
+    if (type >= MAX_WPN_SLOTS)
+    {
+      LOG_ERROR("profile_load: invalid weapon type {} in slot {}", type, i);
+      fclose(fp);
+      return 1;
+    }
 
     int level   = fgetl(fp);
     int xp      = fgetl(fp);


### PR DESCRIPTION
There are two crashes/segfaults in `profile_load` which could be turned into arbitrary writes. First, the `fgetl` and `fgeti` functions don't check if you've reached the end of the file, which causes a too-small `profile.dat` to fill the `Profile` with whatever garbage stack values and leads to a crash, if you call `profile_load` directly.

```xxd
00000000: 446f 3034 3132 3230                      Do041220
```

In the next crash we set the item type to some large value, like `0x5C000000`.

```xxd
00000000: 446f 3034 3132 3230 0d00 0000 0800 0000  Do041220........
00000010: 2de6 0100 20e0 0000 0200 0000 0300 0000  -... ...........
00000020: 0300 0000 0000 0000 0000 0000 0000 0000  ................
00000030: 0000 0000 0000 0000 0000 005c 5c5c 5c5c  ...........\\\\\
00000040: 5c5c 5c5c 5c5c 5c5c 5c5c 5c5c            \\\\\\\\\\\\
```

When we reach the following code block, we'll attempt to write to some large offset and most likely segfault.

```c
    int level   = fgetl(fp);
    int xp      = fgetl(fp);
    int maxammo = fgetl(fp);
    int ammo    = fgetl(fp);

    file->weapons[type].hasWeapon = true;
    file->weapons[type].level     = (level - 1);
    file->weapons[type].xp        = xp;
    file->weapons[type].ammo      = ammo;
    file->weapons[type].maxammo   = maxammo;
```

This patch fixes the two crashes by adding a check to the `fgeti` and `fgetl` functions and making sure the `type` is within the maximum number of weapons. 

**Note:** I have no idea if this will break existing saves in some way, but I don't think it will. I have a similar PR open in the NXEngine repo: https://github.com/EXL/NXEngine/pull/9.