### PR TITLE
account for negative type (d'oh)

### DIFF
--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -69,7 +69,7 @@ bool profile_load(const char *pfname, Profile *file)
     int type = fgetl(fp);
     if (!type)
       break;
-    if (type >= MAX_WPN_SLOTS)
+    if (type < 0 || type >= MAX_WPN_SLOTS)
     {
       LOG_ERROR("profile_load: invalid weapon type {} in slot {}", type, i);
       fclose(fp);


### PR DESCRIPTION
Self explanatory. Types can also be negative, which also crashes.