### PR TITLE
Fix loading weapons 9-13

### DIFF
--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -69,7 +69,7 @@ bool profile_load(const char *pfname, Profile *file)
     int type = fgetl(fp);
     if (!type)
       break;
-    if (type < 0 || type >= MAX_WPN_SLOTS)
+    if (type < 0 || type >= WPN_COUNT)
     {
       LOG_ERROR("profile_load: invalid weapon type {} in slot {}", type, i);
       fclose(fp);


### PR DESCRIPTION
The new check to prevent crashes during profile loading only allowed weapons up to MAX_WPN_SLOTS (8). There are weapons with an index of higher than 8 in the game.