### PR TITLE
Added support for 1280*800 and 800*480 resolutions

### DIFF
--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -226,8 +226,10 @@ const Graphics::gres_t *Renderer::getResolutions(bool full_list)
          {(char *)"1600x1200", 1600, 1200, 320, 240, 5, false, true},
          // widescreen
          {(char *)"480x272", 480, 272, 480, 272, 1, true, true},
+         {(char *)"800x480", 800, 480, 400, 240, 2, true, true},
          {(char *)"1024x600", 1024, 600, 512, 300, 2, true, true},
          {(char *)"1280x720", 1280, 720, 427, 240, 3, true, true},
+         {(char *)"1280x800", 1280, 800, 427, 267, 3, true, true},
          {(char *)"1360x768", 1360, 768, 454, 256, 3, true, true},
          {(char *)"1366x768", 1366, 768, 455, 256, 3, true, true},
          {(char *)"1440x900", 1440, 900, 480, 300, 3, true, true},


### PR DESCRIPTION
Added support for 1280*800 and 800*480 resolutions, to make the game playable on the Steam Deck, as well as on the EeePC line of Asus netbooks.