### PR TITLE
Don't show the Sue title after completing the game without niku counter

### DIFF
--- a/src/niku.cpp
+++ b/src/niku.cpp
@@ -14,8 +14,9 @@
         to decrypt each instance, for a total of 20 bytes.
 */
 
-// load the contents of 290.rec and store in value_out. Returns 0 on success.
-// If there is no such file or an error occurs, writes 0 to value_out.
+// Return the contents of 290.rec.
+// On success: 0 < value < 0xFFFFFFFF
+// Return 0xFFFFFFFF if there is an error or no time has been set yet.
 uint32_t niku_load()
 {
   FILE *fp;
@@ -60,12 +61,16 @@ uint32_t niku_load()
     LOG_ERROR("niku_load: value mismatch; '{}' corrupt", fname);
     return 0xFFFFFFFF;
   }
+  else if (*result == 0)
+  {
+    LOG_DEBUG("niku_load: niku time not set: loaded value 0 from {}", fname);
+    return 0xFFFFFFFF;
+  }
   else
   {
     LOG_DEBUG("niku_load: loaded value {:#08x} from {}", *result, fname);
     return *result;
   }
-  return 0xFFFFFFFF;
 }
 
 // save the timestamp in value to 290.rec.


### PR DESCRIPTION
If you finish Sacred Grounds without the nikumaru counter, the game saves "0" in 290.rec. This used to have two consequences:

1. The title screen would change to the Sue screen, the best possible.
2. If you ever beat Sacred Grounds with the nikumaru counter, your new time would never be better than 0 and would not be saved.

Now if we load 290.rec and see that it's 0, we don't take that value literally. We assume 0 to mean that no time has been set. This fixes both issues.

Fixes #255