### PR TITLE
Changed freedesktop platform to 23.08 for flatpak

### DIFF
--- a/org.nxengine.nxengine_evo.json
+++ b/org.nxengine.nxengine_evo.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "org.nxengine.nxengine_evo",
 	"runtime": "org.freedesktop.Platform",
-	"runtime-version": "20.08",
+	"runtime-version": "23.08",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "nxengine-evo",
 	"finish-args": [


### PR DESCRIPTION
20.08 is at end of life and needs to be changed. No problems seem to happen when moving to 23.08.

Related to #292 