### PR TITLE
Fix common.download-extern.sh

### DIFF
--- a/build-scripts/utils/common.download-extern.sh
+++ b/build-scripts/utils/common.download-extern.sh
@@ -21,21 +21,21 @@ else
 	echo 'Neither of commands `wget` and `curl` (HTTPS downloader) found, aborting!' >&2 && exit 1
 fi
 type jq        >/dev/null 2>&1 || ( echo 'Required command `jq` (JSON query) not found, aborting!'        >&2 && exit 1 )
-type sha256sum >/dev/null 2>&1 || ( echo 'Required command `sha256sum` (file hasher) not found, aborting!' >&2 && exit 1 )
+type sha512sum >/dev/null 2>&1 || ( echo 'Required command `sha512sum` (file hasher) not found, aborting!' >&2 && exit 1 )
 type unzip     >/dev/null 2>&1 || ( echo 'Required command `unzip` (ZIP extractor) not found, aborting!'  >&2 && exit 1 )
 
 
 # Download, verify and extract external resources mentioned in the Flatpak builder manifest
 mkdir -p extern
-jq -r '.modules[0].sources[] | select(.type=="archive") | (.sha256 + " " + .url + " " + .dest)' "${APP_ID}.json" | while read sha256 url dest;
+jq -r '.modules[].sources[] | select(.type=="archive") | (.sha512 + " " + .url + " " + .dest)' "${APP_ID}.json" | while read sha512 url dest;
 do
 	origname="${url##*/}"
-	filepath="extern/${sha256}.${origname#*.}"
+	filepath="extern/${sha512}.${origname#*.}"
 	
 	# Download and verify archive file
 	test -e "${filepath}" || ${DOWNLOAD_CMD} "${filepath}" "${url}"
 	
-	echo "${sha256}  ${filepath}" | sha256sum -c
+	echo "${sha512}  ${filepath}" | sha512sum -c
 	
 	# Extract archive and move it to the same location that it would end up in the Flatpak build
 	case "${dest}" in

--- a/org.nxengine.nxengine_evo.json
+++ b/org.nxengine.nxengine_evo.json
@@ -43,14 +43,14 @@
 				{
 					"type": "archive",
 					"url": "https://github.com/nxengine/translations/releases/download/v1.14/all.zip",
-					"sha256": "1dd85a8c230c5ebf23c6fd6283fe168d9bf4044339d1e93e324bd336165a4422",
+					"sha512": "095d04f374b73b711eb32309d7dbd1c16a098dbe421866e0c422be126b84659ad7791e580b65c299d48412b58fa0c61ce0f670218b08b68b899aae9d17d3161a",
 					"strip-components": 2,
 					"dest": "extern/Translations"
 				},
 				{
 					"type": "archive",
 					"url": "https://sarcasticat.com/cavestoryen.zip",
-					"sha256": "aa87fa30bee9b4980640c7e104791354e0f1f6411ee0d45a70af70046aa0685f",
+					"sha512": "9c7c2c6c8114974df14b1dce379b86da48caf299716e1de3d743e47c3ac6a8c13c4a0ada85778e69f11c2428f991dcbfcb0020212279f9c1787260102988cbc3",
 					"dest": "extern/CaveStory"
 				}
 			],


### PR DESCRIPTION
PR #307 changed the structure of the Flatpak manifest and added a sha512 sum. This broke common.download-extern.sh, which assumed there was only one module and all sources used sha256.